### PR TITLE
fix: call `onBuildComplete` method in `dockerManager` after removing …

### DIFF
--- a/node/src/main/java/me/nateweisz/node/docker/BuildContainerCallback.java
+++ b/node/src/main/java/me/nateweisz/node/docker/BuildContainerCallback.java
@@ -37,7 +37,7 @@ public class BuildContainerCallback extends Thread {
             dockerManager.getClient().removeContainerCmd(container.getId())
                     .exec();
             
-            dockerManager.
+            dockerManager.onBuildComplete(container.getId());
         }
     }
 }


### PR DESCRIPTION
…container